### PR TITLE
Remove the limitation on peerDependecies versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amplify-i18n",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Translations for AWS Amplify",
   "main": "./src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/Locale/amplify-i18n#readme",
   "peerDependencies": {
-    "@aws-amplify/core": "^3.0.0",
-    "@aws-amplify/ui-components": "^0.3.0"
+    "@aws-amplify/core": ">=3.0.0",
+    "@aws-amplify/ui-components": ">=0.3.0"
   }
 }


### PR DESCRIPTION
It prevents to use the lib with the recent versions of amplify.